### PR TITLE
fix issue #482- no icon encryption when burning

### DIFF
--- a/packages/app-lixi/src/components/Wallet/FullWallet.tsx
+++ b/packages/app-lixi/src/components/Wallet/FullWallet.tsx
@@ -278,10 +278,12 @@ const FullWalletComponent: React.FC = () => {
                                       </p>
                                     )}
                                   </p>
-                                  <p className="tx-memo">
+                                  {!_.isEmpty(memo) && <p className="tx-memo">
                                     <LockOutlined /> {memo}
                                   </p>
+                                  }
                                 </div>
+
                               }
                             />
                             <div className="tx-info">


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/102006405/227123508-e87ccdf5-a21a-4eb0-824f-5eb91177b906.png)
fix successfully.
When we get message, we will see the icon encryption  and message next to it. Burn will not get icon encryption like before