### PR TITLE
Exclude path for open graph

### DIFF
--- a/packages/app-lixi/src/middleware.ts
+++ b/packages/app-lixi/src/middleware.ts
@@ -10,7 +10,8 @@ function shouldExclude(request: NextRequest) {
     path.startsWith('/_api') || //  exclude all API routes
     path.startsWith('/static') || // exclude static files
     path.includes('.') || // exclude all files in the public folder
-    path.startsWith('/claimed')
+    path.startsWith('/claimed') ||
+    path.startsWith('/post')
   );
 }
 


### PR DESCRIPTION
Should enable open graph for post. If it won't work, will revert in the next commit